### PR TITLE
PAR-42: FPクエリビルダー ドキュメント整備（サブテーブル/関連/未サポート/raw非提供）

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -406,6 +406,11 @@ const records = await client.record.getRecords({
 - **複雑な条件**: `and()`、`or()`、`not()` で組み合わせ
 - **自動補完**: IDEがフィールドとメソッドの候補を提供
 
+### 補足: raw() の非提供
+
+生クエリを直接挿入する `raw()` は提供しません。代替として、
+`contains/startsWith/endsWith`、`between(min, max)`、`customDateFunction/customUserFunction` を利用してください。
+
 ### フィールドタイプ別の例
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -419,6 +419,12 @@ const records = await client.record.getRecords({
 - **Complex conditions**: Combine with `and()`, `or()`, `not()`
 - **Auto-completion**: IDE provides suggestions for fields and methods
 
+### Note: No `raw()` escape hatch
+
+Direct raw query insertion via `raw()` is not provided. Instead, use
+`contains/startsWith/endsWith`, `between(min, max)`, and
+`customDateFunction/customUserFunction` as escape hatches.
+
 ### Field Type Examples
 
 ```typescript

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -119,6 +119,12 @@ sequenceDiagram
 
 - `src/core/query-generator.ts` は FP API をimportし、使いやすい `createQuery()` ファサードを公開
 
+### 生成器の補足
+
+- 未サポートフィールドは生成物から除外し、警告コメントを出力します。
+- `--include-subtable=false` を明示した場合、`SUBTABLE` は完全に無視し、コメントも出力しません。
+- `--include-related` 指定時は `REFERENCE_TABLE` の `displayFields` だけを `createTableSubField('親.子')` で最小公開します（`in/not in` のみ）。
+
 ```mermaid
 flowchart LR
   META[Form Metadata] --> GEN[query-generator.ts]

--- a/docs/query-builder.ja.md
+++ b/docs/query-builder.ja.md
@@ -80,3 +80,25 @@ flowchart TD
 - 文字列: `contains()/startsWith()/endsWith()`
 - 数値/日付/日時/時間: `between(min, max)`
 - 関数（未サポート名）: `customDateFunction(name, ...args)` / `customUserFunction(name, ...args)`
+
+## サブテーブル/関連レコードの扱い
+
+- `--include-subtable` を指定すると、サブテーブルの子フィールドを `createTableSubField('親.子')` で最小API（`in/not in` のみ）として公開します。
+- `--include-related` を指定すると、関連レコード（`REFERENCE_TABLE`）の `displayFields` を同様に最小APIとして公開します。
+- 明示的に `--include-subtable=false` の場合、サブテーブルは生成物から完全に除外され、警告コメントも出しません。
+
+## 未サポートフィールド
+
+以下のフィールドタイプはクエリでは非対応のため、生成器は出力から除外します（`SUBTABLE` は上記のとおりオプションで扱いが変わります）。
+
+- 例: `FILE`, `CATEGORY`, `STATUS`, `STATUS_ASSIGNEE`, `CREATED_TIME`, `UPDATED_TIME`, `CREATOR`, `MODIFIER`, `RECORD_NUMBER`, `GROUP`, `SPACER`, `LABEL`, `REFERENCE_TABLE`（関連は `--include-related` で最小公開）
+
+除外時は、警告コメント `// フィールドコード: TYPE type is not supported` を出力します（`--include-subtable=false` のときの `SUBTABLE` はコメントも抑制）。
+
+## raw() の非提供について
+
+生クエリを挿入する `raw()` は提供しません。代替として以下を利用できます。
+
+- 文字列: `contains/startsWith/endsWith`
+- 数値/日付/時間: `between(min, max)`
+- 名前での関数指定: `customDateFunction(name, ...args)` / `customUserFunction(name, ...args)`


### PR DESCRIPTION
ドキュメントをFP方針に合わせて更新しました。\n\n- docs/query-builder.ja.md: サブテーブル/関連レコードの最小公開（createTableSubField）、未サポートフィールドのコメント方針、時の無視、raw()非提供の明記\n- docs/architecture.ja.md: 生成器の補足を追記（未サポート/関連/サブテーブルの方針）\n- README.ja.md / README.md: raw()非提供の注記を追記\n\n実装は既に対応済み（PR #2）。本PRはドキュメントの整合です。\n\n関連: PAR-42