### PR TITLE
docs(readme): fix heading level for Helper methods / 補助メソッド (PAR-67)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -399,7 +399,7 @@ const records = await client.record.getRecords({
 });
 ```
 
-#### 補助メソッド
+### 補助メソッド
 
 - 文字列: `contains()/startsWith()/endsWith()`
 - 数値/日付/日時/時間: `between(min, max)`

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ const records = await client.record.getRecords({
 });
 ```
 
-#### Helper methods
+### Helper methods
 
 - Strings: `contains()/startsWith()/endsWith()`
 - Numbers/Date/DateTime/Time: `between(min, max)`


### PR DESCRIPTION
Change h4 to h3 in README.md and README.ja.md.