### PR TITLE
test(query): rename toString import to expressionToString (PAR-64)

### DIFF
--- a/src/query/__tests__/expression.test.ts
+++ b/src/query/__tests__/expression.test.ts
@@ -1,109 +1,109 @@
 import { describe, it, expect } from 'vitest';
-import { condition, toString, and, or, not } from '../expression.js';
+import { condition, toString as expressionToString, and, or, not } from '../expression.js';
 
 describe('Condition', () => {
   describe('基本的な等価条件', () => {
     it('文字列フィールドの等価条件を生成できる', () => {
       const expr = condition('会社名', '=', 'サイボウズ');
-      expect(toString(expr)).toBe('会社名 = "サイボウズ"');
+      expect(expressionToString(expr)).toBe('会社名 = "サイボウズ"');
     });
 
     it('数値フィールドの等価条件を生成できる', () => {
       const expr = condition('売上高', '=', 1000000);
-      expect(toString(expr)).toBe('売上高 = 1000000');
+      expect(expressionToString(expr)).toBe('売上高 = 1000000');
     });
 
     it('真偽値フィールドの等価条件を生成できる', () => {
       const expr = condition('有効フラグ', '=', true);
-      expect(toString(expr)).toBe('有効フラグ = true');
+      expect(expressionToString(expr)).toBe('有効フラグ = true');
     });
   });
 
   describe('比較演算子', () => {
     it('より大きい条件を生成できる', () => {
       const expr = condition('売上高', '>', 1000000);
-      expect(toString(expr)).toBe('売上高 > 1000000');
+      expect(expressionToString(expr)).toBe('売上高 > 1000000');
     });
 
     it('より小さい条件を生成できる', () => {
       const expr = condition('在庫数', '<', 100);
-      expect(toString(expr)).toBe('在庫数 < 100');
+      expect(expressionToString(expr)).toBe('在庫数 < 100');
     });
 
     it('以上条件を生成できる', () => {
       const expr = condition('売上高', '>=', 1000000);
-      expect(toString(expr)).toBe('売上高 >= 1000000');
+      expect(expressionToString(expr)).toBe('売上高 >= 1000000');
     });
 
     it('以下条件を生成できる', () => {
       const expr = condition('在庫数', '<=', 100);
-      expect(toString(expr)).toBe('在庫数 <= 100');
+      expect(expressionToString(expr)).toBe('在庫数 <= 100');
     });
 
     it('不等価条件を生成できる', () => {
       const expr = condition('ステータス', '!=', '完了');
-      expect(toString(expr)).toBe('ステータス != "完了"');
+      expect(expressionToString(expr)).toBe('ステータス != "完了"');
     });
   });
 
   describe('IN演算子', () => {
     it('複数値のIN条件を生成できる', () => {
       const expr = condition('ステータス', 'in', ['商談中', '受注']);
-      expect(toString(expr)).toBe('ステータス in ("商談中", "受注")');
+      expect(expressionToString(expr)).toBe('ステータス in ("商談中", "受注")');
     });
 
     it('数値配列のIN条件を生成できる', () => {
       const expr = condition('優先度', 'in', [1, 2, 3]);
-      expect(toString(expr)).toBe('優先度 in (1, 2, 3)');
+      expect(expressionToString(expr)).toBe('優先度 in (1, 2, 3)');
     });
 
     it('NOT IN条件を生成できる', () => {
       const expr = condition('ステータス', 'not in', ['失注', 'キャンセル']);
-      expect(toString(expr)).toBe('ステータス not in ("失注", "キャンセル")');
+      expect(expressionToString(expr)).toBe('ステータス not in ("失注", "キャンセル")');
     });
   });
 
   describe('LIKE演算子', () => {
     it('部分一致条件を生成できる', () => {
       const expr = condition('会社名', 'like', '*サイボウズ*');
-      expect(toString(expr)).toBe('会社名 like "*サイボウズ*"');
+      expect(expressionToString(expr)).toBe('会社名 like "*サイボウズ*"');
     });
 
     it('前方一致条件を生成できる', () => {
       const expr = condition('電話番号', 'like', '03*');
-      expect(toString(expr)).toBe('電話番号 like "03*"');
+      expect(expressionToString(expr)).toBe('電話番号 like "03*"');
     });
 
     it('後方一致条件を生成できる', () => {
       const expr = condition('メールアドレス', 'like', '*@cybozu.com');
-      expect(toString(expr)).toBe('メールアドレス like "*@cybozu.com"');
+      expect(expressionToString(expr)).toBe('メールアドレス like "*@cybozu.com"');
     });
 
     it('NOT LIKE条件を生成できる', () => {
       const expr = condition('会社名', 'not like', '*テスト*');
-      expect(toString(expr)).toBe('会社名 not like "*テスト*"');
+      expect(expressionToString(expr)).toBe('会社名 not like "*テスト*"');
     });
   });
 
   describe('特殊な値の処理', () => {
     it('空文字列を正しく処理できる', () => {
       const expr = condition('備考', '=', '');
-      expect(toString(expr)).toBe('備考 = ""');
+      expect(expressionToString(expr)).toBe('備考 = ""');
     });
 
     it('nullを正しく処理できる', () => {
       const expr = condition('削除日', '=', null);
-      expect(toString(expr)).toBe('削除日 = null');
+      expect(expressionToString(expr)).toBe('削除日 = null');
     });
 
     it('undefinedをnullとして処理できる', () => {
       const expr = condition('更新日', '=', undefined);
-      expect(toString(expr)).toBe('更新日 = null');
+      expect(expressionToString(expr)).toBe('更新日 = null');
     });
 
     it('ダブルクォートを含む文字列をエスケープできる', () => {
       const expr = condition('会社名', '=', 'サイボウズ"株式会社"');
-      expect(toString(expr)).toBe('会社名 = "サイボウズ\\"株式会社\\""');
+      expect(expressionToString(expr)).toBe('会社名 = "サイボウズ\\"株式会社\\""');
     });
   });
 });
@@ -113,7 +113,7 @@ describe('AND演算子', () => {
     const cond1 = condition('会社名', '=', 'サイボウズ');
     const cond2 = condition('売上高', '>', 1000000);
     const expr = and(cond1, cond2);
-    expect(toString(expr)).toBe('(会社名 = "サイボウズ" and 売上高 > 1000000)');
+    expect(expressionToString(expr)).toBe('(会社名 = "サイボウズ" and 売上高 > 1000000)');
   });
 
   it('3つ以上の条件をANDで結合できる', () => {
@@ -121,7 +121,7 @@ describe('AND演算子', () => {
     const cond2 = condition('売上高', '>', 1000000);
     const cond3 = condition('ステータス', 'in', ['商談中', '受注']);
     const expr = and(cond1, cond2, cond3);
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '(会社名 = "サイボウズ" and 売上高 > 1000000 and ステータス in ("商談中", "受注"))'
     );
   });
@@ -129,7 +129,7 @@ describe('AND演算子', () => {
   it('単一条件のANDは括弧を付けない', () => {
     const cond = condition('会社名', '=', 'サイボウズ');
     const expr = and(cond);
-    expect(toString(expr)).toBe('会社名 = "サイボウズ"');
+    expect(expressionToString(expr)).toBe('会社名 = "サイボウズ"');
   });
 });
 
@@ -138,7 +138,7 @@ describe('OR演算子', () => {
     const cond1 = condition('ステータス', '=', '商談中');
     const cond2 = condition('ステータス', '=', '受注');
     const expr = or(cond1, cond2);
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '(ステータス = "商談中" or ステータス = "受注")'
     );
   });
@@ -148,7 +148,7 @@ describe('OR演算子', () => {
     const cond2 = condition('優先度', '=', '中');
     const cond3 = condition('優先度', '=', '低');
     const expr = or(cond1, cond2, cond3);
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '(優先度 = "高" or 優先度 = "中" or 優先度 = "低")'
     );
   });
@@ -156,7 +156,7 @@ describe('OR演算子', () => {
   it('単一条件のORは括弧を付けない', () => {
     const cond = condition('ステータス', '=', '完了');
     const expr = or(cond);
-    expect(toString(expr)).toBe('ステータス = "完了"');
+    expect(expressionToString(expr)).toBe('ステータス = "完了"');
   });
 });
 
@@ -164,7 +164,7 @@ describe('NOT演算子', () => {
   it('条件を否定できる', () => {
     const cond = condition('ステータス', '=', '完了');
     const expr = not(cond);
-    expect(toString(expr)).toBe('not (ステータス = "完了")');
+    expect(expressionToString(expr)).toBe('not (ステータス = "完了")');
   });
 
   it('複雑な条件を否定できる', () => {
@@ -172,7 +172,7 @@ describe('NOT演算子', () => {
     const cond2 = condition('売上高', '<', 5000000);
     const andExpr = and(cond1, cond2);
     const expr = not(andExpr);
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       'not ((売上高 > 1000000 and 売上高 < 5000000))'
     );
   });
@@ -187,7 +187,7 @@ describe('ネスト条件', () => {
     const assigned = condition('担当者', '=', 'LOGINUSER()');
     const expr = or(important, assigned);
 
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '((優先度 = "高" and 緊急フラグ = true) or 担当者 = LOGINUSER())'
     );
   });
@@ -200,7 +200,7 @@ describe('ネスト条件', () => {
     const highValue = condition('売上高', '>', 10000000);
     const expr = and(activeStatuses, highValue);
 
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '((ステータス = "商談中" or ステータス = "受注") and 売上高 > 10000000)'
     );
   });
@@ -215,7 +215,7 @@ describe('ネスト条件', () => {
 
     const expr = or(and(a, or(b, c)), and(d, e, not(f)));
 
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '((A = "1" and (B = "2" or C = "3")) or (D = "4" and E = "5" and not (F = "6")))'
     );
   });
@@ -224,20 +224,20 @@ describe('ネスト条件', () => {
 describe('関数や比較の等価表現', () => {
   it('登録日 >= NOW() を condition で表現できる', () => {
     const expr = condition('登録日', '>=', 'NOW()');
-    expect(toString(expr)).toBe('登録日 >= NOW()');
+    expect(expressionToString(expr)).toBe('登録日 >= NOW()');
   });
 
   it('ANDの右項を数値比較で置き換え', () => {
     const left = condition('会社名', 'like', '*サイボウズ*');
     const right = condition('売上高', '>', 1000000);
     const expr = and(left, right);
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '(会社名 like "*サイボウズ*" and 売上高 > 1000000)'
     );
   });
 
   it('NOT (ステータス in ("完了")) を型安全APIで表現', () => {
     const expr = not(condition('ステータス', 'in', ['完了']));
-    expect(toString(expr)).toBe('not (ステータス in ("完了"))');
+    expect(expressionToString(expr)).toBe('not (ステータス in ("完了"))');
   });
 });

--- a/src/query/__tests__/field.test.ts
+++ b/src/query/__tests__/field.test.ts
@@ -1,13 +1,4 @@
-import { describe, it, expect } from 'vitest';
-import {
-  createStringField,
-  createNumberField,
-  createDropdownField,
-  createCheckboxField,
-  createDateField,
-  createUserField,
-  toString,
-} from '../field.js';
+import { $1toString as expressionToString,$2 } from '../field.js';
 import { TODAY, FROM_TODAY, LOGINUSER, NOW } from '../functions.js';
 
 describe('StringField', () => {
@@ -15,42 +6,42 @@ describe('StringField', () => {
 
   it('equals演算子が使える', () => {
     const expr = 会社名Field.equals('サイボウズ');
-    expect(toString(expr)).toBe('会社名 = "サイボウズ"');
+    expect(expressionToString(expr)).toBe('会社名 = "サイボウズ"');
   });
 
   it('notEquals演算子が使える', () => {
     const expr = 会社名Field.notEquals('サイボウズ');
-    expect(toString(expr)).toBe('会社名 != "サイボウズ"');
+    expect(expressionToString(expr)).toBe('会社名 != "サイボウズ"');
   });
 
   it('like演算子が使える', () => {
     const expr = 会社名Field.like('*サイボウズ*');
-    expect(toString(expr)).toBe('会社名 like "*サイボウズ*"');
+    expect(expressionToString(expr)).toBe('会社名 like "*サイボウズ*"');
   });
 
   it('notLike演算子が使える', () => {
     const expr = 会社名Field.notLike('*サイボウズ*');
-    expect(toString(expr)).toBe('会社名 not like "*サイボウズ*"');
+    expect(expressionToString(expr)).toBe('会社名 not like "*サイボウズ*"');
   });
 
   it('contains/startsWith/endsWith が使える', () => {
-    expect(toString(会社名Field.contains('株式'))).toBe('会社名 like "*株式*"');
-    expect(toString(会社名Field.startsWith('サイ'))).toBe(
+    expect(expressionToString(会社名Field.contains('株式'))).toBe('会社名 like "*株式*"');
+    expect(expressionToString(会社名Field.startsWith('サイ'))).toBe(
       '会社名 like "サイ*"'
     );
-    expect(toString(会社名Field.endsWith('ボウズ'))).toBe(
+    expect(expressionToString(会社名Field.endsWith('ボウズ'))).toBe(
       '会社名 like "*ボウズ"'
     );
   });
 
   it('in演算子が使える', () => {
     const expr = 会社名Field.in(['サイボウズ', 'kintone']);
-    expect(toString(expr)).toBe('会社名 in ("サイボウズ", "kintone")');
+    expect(expressionToString(expr)).toBe('会社名 in ("サイボウズ", "kintone")');
   });
 
   it('notIn演算子が使える', () => {
     const expr = 会社名Field.notIn(['テスト', 'デモ']);
-    expect(toString(expr)).toBe('会社名 not in ("テスト", "デモ")');
+    expect(expressionToString(expr)).toBe('会社名 not in ("テスト", "デモ")');
   });
 });
 
@@ -59,47 +50,47 @@ describe('NumberField', () => {
 
   it('equals演算子が使える', () => {
     const expr = 売上高Field.equals(1000000);
-    expect(toString(expr)).toBe('売上高 = 1000000');
+    expect(expressionToString(expr)).toBe('売上高 = 1000000');
   });
 
   it('notEquals演算子が使える', () => {
     const expr = 売上高Field.notEquals(0);
-    expect(toString(expr)).toBe('売上高 != 0');
+    expect(expressionToString(expr)).toBe('売上高 != 0');
   });
 
   it('greaterThan演算子が使える', () => {
     const expr = 売上高Field.greaterThan(1000000);
-    expect(toString(expr)).toBe('売上高 > 1000000');
+    expect(expressionToString(expr)).toBe('売上高 > 1000000');
   });
 
   it('lessThan演算子が使える', () => {
     const expr = 売上高Field.lessThan(1000000);
-    expect(toString(expr)).toBe('売上高 < 1000000');
+    expect(expressionToString(expr)).toBe('売上高 < 1000000');
   });
 
   it('greaterThanOrEqual演算子が使える', () => {
     const expr = 売上高Field.greaterThanOrEqual(1000000);
-    expect(toString(expr)).toBe('売上高 >= 1000000');
+    expect(expressionToString(expr)).toBe('売上高 >= 1000000');
   });
 
   it('lessThanOrEqual演算子が使える', () => {
     const expr = 売上高Field.lessThanOrEqual(1000000);
-    expect(toString(expr)).toBe('売上高 <= 1000000');
+    expect(expressionToString(expr)).toBe('売上高 <= 1000000');
   });
 
   it('betweenが使える', () => {
     const expr = 売上高Field.between(100, 200);
-    expect(toString(expr)).toBe('(売上高 >= 100 and 売上高 <= 200)');
+    expect(expressionToString(expr)).toBe('(売上高 >= 100 and 売上高 <= 200)');
   });
 
   it('in演算子が使える', () => {
     const expr = 売上高Field.in([100, 200, 300]);
-    expect(toString(expr)).toBe('売上高 in (100, 200, 300)');
+    expect(expressionToString(expr)).toBe('売上高 in (100, 200, 300)');
   });
 
   it('notIn演算子が使える', () => {
     const expr = 売上高Field.notIn([0, -1]);
-    expect(toString(expr)).toBe('売上高 not in (0, -1)');
+    expect(expressionToString(expr)).toBe('売上高 not in (0, -1)');
   });
 });
 
@@ -113,12 +104,12 @@ describe('DropdownField', () => {
 
   it('in演算子が使える', () => {
     const expr = ステータスField.in(['商談中', '受注']);
-    expect(toString(expr)).toBe('ステータス in ("商談中", "受注")');
+    expect(expressionToString(expr)).toBe('ステータス in ("商談中", "受注")');
   });
 
   it('notIn演算子が使える', () => {
     const expr = ステータスField.notIn(['失注', '保留']);
-    expect(toString(expr)).toBe('ステータス not in ("失注", "保留")');
+    expect(expressionToString(expr)).toBe('ステータス not in ("失注", "保留")');
   });
 
   // ドロップダウンフィールドはequals演算子を持たない（型エラーになる）
@@ -135,12 +126,12 @@ describe('CheckboxField', () => {
 
   it('in演算子が使える', () => {
     const expr = タグField.in(['重要', '緊急']);
-    expect(toString(expr)).toBe('タグ in ("重要", "緊急")');
+    expect(expressionToString(expr)).toBe('タグ in ("重要", "緊急")');
   });
 
   it('notIn演算子が使える', () => {
     const expr = タグField.notIn(['確認済み']);
-    expect(toString(expr)).toBe('タグ not in ("確認済み")');
+    expect(expressionToString(expr)).toBe('タグ not in ("確認済み")');
   });
 });
 
@@ -149,34 +140,34 @@ describe('DateField', () => {
 
   it('文字列の日付でequals演算子が使える', () => {
     const expr = 契約日Field.equals('2024-01-01');
-    expect(toString(expr)).toBe('契約日 = "2024-01-01"');
+    expect(expressionToString(expr)).toBe('契約日 = "2024-01-01"');
   });
 
   it('TODAY関数でequals演算子が使える', () => {
     const expr = 契約日Field.equals(TODAY());
-    expect(toString(expr)).toBe('契約日 = TODAY()');
+    expect(expressionToString(expr)).toBe('契約日 = TODAY()');
   });
 
   it('FROM_TODAY関数でgreaterThan演算子が使える', () => {
     const expr = 契約日Field.greaterThan(FROM_TODAY(-30, 'DAYS'));
-    expect(toString(expr)).toBe('契約日 > FROM_TODAY(-30, "DAYS")');
+    expect(expressionToString(expr)).toBe('契約日 > FROM_TODAY(-30, "DAYS")');
   });
 
   it('lessThanOrEqual演算子が使える', () => {
     const expr = 契約日Field.lessThanOrEqual(TODAY());
-    expect(toString(expr)).toBe('契約日 <= TODAY()');
+    expect(expressionToString(expr)).toBe('契約日 <= TODAY()');
   });
 
   it('in演算子で複数の日付を指定できる', () => {
     const expr = 契約日Field.in(['2024-01-01', '2024-02-01', '2024-03-01']);
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '契約日 in ("2024-01-01", "2024-02-01", "2024-03-01")'
     );
   });
 
   it('betweenが使える（関数を含む）', () => {
     const expr = 契約日Field.between(FROM_TODAY(-7, 'DAYS'), NOW());
-    expect(toString(expr)).toBe(
+    expect(expressionToString(expr)).toBe(
       '(契約日 >= FROM_TODAY(-7, "DAYS") and 契約日 <= NOW())'
     );
   });
@@ -187,22 +178,22 @@ describe('UserField', () => {
 
   it('文字列（ユーザー名）でequals演算子が使える', () => {
     const expr = 担当者Field.equals('田中太郎');
-    expect(toString(expr)).toBe('担当者 = "田中太郎"');
+    expect(expressionToString(expr)).toBe('担当者 = "田中太郎"');
   });
 
   it('LOGINUSER関数でequals演算子が使える', () => {
     const expr = 担当者Field.equals(LOGINUSER());
-    expect(toString(expr)).toBe('担当者 = LOGINUSER()');
+    expect(expressionToString(expr)).toBe('担当者 = LOGINUSER()');
   });
 
   it('in演算子で複数のユーザーを指定できる', () => {
     const expr = 担当者Field.in(['田中太郎', '鈴木花子']);
-    expect(toString(expr)).toBe('担当者 in ("田中太郎", "鈴木花子")');
+    expect(expressionToString(expr)).toBe('担当者 in ("田中太郎", "鈴木花子")');
   });
 
   it('notIn演算子が使える', () => {
     const expr = 担当者Field.notIn(['システム', 'ゲスト']);
-    expect(toString(expr)).toBe('担当者 not in ("システム", "ゲスト")');
+    expect(expressionToString(expr)).toBe('担当者 not in ("システム", "ゲスト")');
   });
 });
 


### PR DESCRIPTION
Avoids shadowing global toString in tests (expression.test.ts, field.test.ts).